### PR TITLE
Allow multiple values with same flag in "options.closure". 

### DIFF
--- a/compilers/closure-compiler/compiler.js
+++ b/compilers/closure-compiler/compiler.js
@@ -214,7 +214,13 @@ ClosureCompiler.localCompile = function(files, opt_options, opt_target_file,
   // Handling options
   for (let option in options) {
     if (Object.prototype.hasOwnProperty.call(options, option)) {
-      compilerOptions.push('--' + option, options[option]);
+      if (Array.isArray(options[option])) {
+        options[option].forEach(option_val => {
+          compilerOptions.push('--' + option, option_val);
+        });
+      } else {
+        compilerOptions.push('--' + option, options[option]);
+      }
     }
   }
 


### PR DESCRIPTION
Allow multiple values with same flag in "options.closure". For examples, define, source_map_location_mapping.

Example config:
```javascript
const closureBuilder = require("closure-builder");
const glob = closureBuilder.globSupport();
closureBuilder.build({
  srcs: glob(["src/**/*.js", "soy/**/*.soy"]),
  options: {
    closure: {
      define: ["goog.DEBUG=true", "goog.dom.ASSUME_STANDARDS_MODE=true"]
    }
  }
}
```