### PR TITLE
Add support for passing options to GSS

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -137,6 +137,9 @@ let BuildConfig = function(config) {
     compilation_level: 'SIMPLE_OPTIMIZATIONS',
   };
 
+  /** @type {!object} */
+  this.closureStylesheetsCompilerOptions = this.options.gss || {};
+
   /** @type {!string} */
   this.soyPath = (this.out) ? this.out : path.join(this.tempPath, 'soy');
 


### PR DESCRIPTION
This pull request adds a simple change that allows passing options to the GSS compiler, through a build config property called `gss`, to match `soy` and `closure`. It is essentially a one-liner to match the property that `closure-builder` looks for in [closure-builder.js](https://github.com/google/closure-builder/blob/master/closure-builder.js#L315).

I figure that support could later be added for some flag defaults to pass to GSS, for instance:
- `copyright-notice` set to whatever `config.banner` is set to (perhaps once that's documented 😉)
- class rewriting integration with Closure, via `output-renaming-map` and friends
- outputting with `pretty-print` when `debug` is set in `closure-builder`

I am happy to go ahead and add the above as long as I get some feedback that the direction here matches with `closure-builder`'s roadmap. Thank you in advance for your time