### PR TITLE
Fixes for use_closure_library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ These options could be used for adding additional information.
 
 #### Options ####
 The following options are available for the closure and soy compiler:
-- `options.use_closure_library` If true bundled closure library will be 
-  included. If a path, the defined path will be included instead.
 - `options.exclude_test` If true *_test.* files will be excluded
 - `options.soy` Additional settings for the Soy compiler
 - `options.closure` Additional settings for the Closure compiler
+- `options.closure.use_closure_library` If true bundled closure library will be
+  included. If a path, the defined path will be included instead.
 ```javascript
 closureBuilder.build({
   srcs: glob([

--- a/build_compilers.js
+++ b/build_compilers.js
@@ -421,7 +421,9 @@ BuildCompilers.compileJsFiles = function(files, out,
       options.use_closure_templates = true;
     }
     if (config.requireClosureLibrary) {
-      options.use_closure_library = true;
+      if (!options.use_closure_library) {
+        options.use_closure_library = true;
+      }
       if (config.requireClosureLibraryUI && !config.remoteService) {
         options.use_closure_library_ui = true;
       }

--- a/compilers/closure-compiler/compiler.js
+++ b/compilers/closure-compiler/compiler.js
@@ -187,9 +187,14 @@ ClosureCompiler.localCompile = function(files, opt_options, opt_target_file,
     delete options.use_closure_templates;
   }
 
+  let closureLibraryFolder = undefined;
+  if (typeof options.use_closure_library === 'string') {
+    closureLibraryFolder = options.use_closure_library;
+  }
+
   // Include Closure base file
   if (options.use_closure_basefile || options.use_closure_library) {
-    let baseFile = pathTools.getClosureBaseFile();
+    let baseFile = pathTools.getClosureBaseFile(closureLibraryFolder);
     if (baseFile) {
       compilerOptions.push('--js', baseFile);
     }
@@ -203,10 +208,6 @@ ClosureCompiler.localCompile = function(files, opt_options, opt_target_file,
       delete options.use_closure_library_ui;
     } else {
       ignoreList.push('ui');
-    }
-    let closureLibraryFolder = undefined;
-    if (typeof options.use_closure_library === 'string') {
-      closureLibraryFolder = options.use_closure_library;
     }
     let closureLibraryFolders = pathTools.getClosureLibraryFolders(
       ignoreList, closureLibraryFolder);

--- a/tools/path.js
+++ b/tools/path.js
@@ -170,9 +170,11 @@ PathTools.getClosureLibraryFolders = function(ignore = [],
 
 /**
  * @return {!string}
+ * @param {string=} libraryPath
  */
-PathTools.getClosureBaseFile = function() {
-  let baseFile = path.join(PathTools.getClosureLibraryPath(), 'closure', 'goog',
+PathTools.getClosureBaseFile = function(
+    libraryPath = PathTools.getClosureLibraryPath()) {
+  let baseFile = path.join(libraryPath, 'closure', 'goog',
     'base.js');
   if (!PathTools.existFile(baseFile)) {
     log.error('Closure base file was not found at', baseFile);


### PR DESCRIPTION
1. Make sure it doesn't get clobbered in build_compilers.js.
2. Respect it when resolving the location of goog/base.js.